### PR TITLE
feat(router): add support to serve app under a specific path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cd ../
 ### build go
 ```bash
 go get github.com/rakyll/statik
-statik --src=web/build  # use statik tool to convert files in 'web/dist' dir to go code, and compile into binary.
+statik --src=web/build  # use statik tool to convert files in 'web/build' dir to go code, and compile into binary.
 export GO111MODULE=on # for go 1.11.x
 go build
 ```

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -5,12 +5,14 @@ site:
   deploy_host: console.hpc.gensh.me
 
 prod:
-  # http path of static files and views
+  # http path for static files and views
   static_prefix: /
+  api_prefix: ""
 
 dev: # config used in debug mode.
-  # https prefix of static files only
+  # http prefix for static files
   static_prefix: /static/
+  api_prefix: /
   # redirect static files requests to this address, redirect "static_prefix" to "static_redirect"
   # for example, static_prefix is "/static", static_redirect is "localhost:8080/dist",
   # this will redirect all requests having prefix "/static" to "localhost:8080/dist"

--- a/src/routers/router.go
+++ b/src/routers/router.go
@@ -49,14 +49,28 @@ func Register() {
 		http.Handle(utils.Config.Prod.StaticPrefix, http.StripPrefix(utils.Config.Prod.StaticPrefix, http.FileServer(statikFS)))
 	}
 
+	// set api prefix
+	apiPrefix := ""
+	if utils.Config.Site.RunMode == RunModeDev && utils.Config.Dev.ApiPrefix != "" {
+		apiPrefix = utils.Config.Dev.ApiPrefix
+	}
+	if utils.Config.Site.RunMode == RunModeProd && utils.Config.Prod.ApiPrefix != "" {
+		apiPrefix = utils.Config.Prod.ApiPrefix
+	}
+	if apiPrefix == "" {
+		log.Println("api serving at endpoint `/`")
+	} else {
+		log.Printf("api serving at endpoint `%s`", apiPrefix)
+	}
+
 	bct := utils.Config.SSH.BufferCheckerCycleTime
 	// api
-	http.HandleFunc("/api/signin", controllers.SignIn)
-	http.HandleFunc("/api/sftp/upload", controllers.AuthPreChecker(files.FileUpload{}))
-	http.HandleFunc("/api/sftp/ls", controllers.AuthPreChecker(files.List{}))
-	http.HandleFunc("/api/sftp/dl", controllers.AuthPreChecker(files.Download{}))
-	http.HandleFunc("/ws/ssh", controllers.AuthPreChecker(controllers.NewSSHWSHandle(bct)))
-	http.HandleFunc("/ws/sftp", controllers.AuthPreChecker(files.SftpEstablish{}))
+	http.HandleFunc(apiPrefix+"/api/signin", controllers.SignIn)
+	http.HandleFunc(apiPrefix+"/api/sftp/upload", controllers.AuthPreChecker(files.FileUpload{}))
+	http.HandleFunc(apiPrefix+"/api/sftp/ls", controllers.AuthPreChecker(files.List{}))
+	http.HandleFunc(apiPrefix+"/api/sftp/dl", controllers.AuthPreChecker(files.Download{}))
+	http.HandleFunc(apiPrefix+"/ws/ssh", controllers.AuthPreChecker(controllers.NewSSHWSHandle(bct)))
+	http.HandleFunc(apiPrefix+"/ws/sftp", controllers.AuthPreChecker(files.SftpEstablish{}))
 }
 
 /*

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -15,13 +15,16 @@ var Config struct {
 	} `yaml:"site"`
 	Prod struct {
 		StaticPrefix string `yaml:"static_prefix"` // http prefix of static and views files
+		ApiPrefix    string `yaml:"api_prefix"`
 	} `yaml:"prod"`
 	Dev struct {
 		StaticPrefix string `yaml:"static_prefix"` // https prefix of only static files
 		//StaticPrefix string `yaml:"static_prefix"` // prefix of static files in dev mode.
+		ApiPrefix string `yaml:"api_prefix"`
+
 		// redirect static files requests to this address, redirect "StaticPrefix" to "StaticRedirect + StaticPrefix"
 		// for example, StaticPrefix is "static", StaticRedirect is "localhost:8080/dist",
-		// this will redirect all requests having prefix "static" to "localhost:8080/dist/"
+		// this will redirect all requests having prefix "static" to "localhost:8080/dist/static/"
 		StaticRedirect string `yaml:"static_redirect"`
 		// http server will read static file from this dir if StaticRedirect is empty
 		StaticDir   string `yaml:"static_dir"`


### PR DESCRIPTION
This feature comes from #10, which need to serve under a path, instead of direct "/".

re #10